### PR TITLE
[fix] invalid event link

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@ ghost_link: https://www.facebook.com/events/3113267502230875/
           </div>
         {% endif %}
           <div class="timeline-heading eventinfo">
-            <a href=https://{{event.link}} target="_blank">
+            <a href='{{event.link}}' target="_blank">
               <h2 class="eventTitle">{{event.title}}</h2>
             </a>
             <h2 class="eventDate">{{event.date}}</h2>


### PR DESCRIPTION
`https` is already added in the link mentioned in upcoming.yml, as the script is trying to add another `https` the link is becoming: 
https://https//www.facebook.com/pg/gutechsoc/events

this proposal fixes that by removing the extra https!