### PR TITLE
Fixed issue with wrong Linkedin URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ ghost_link: https://www.facebook.com/events/3113267502230875/
                   <h4>Eilidh Sweenie</h4>
                   <span class="role">Secretary</span>
                   <div class="social">
-                    <a target="_blank" href="linkedin.com/in/eilidhsweenie"><i class="fab fa-linkedin"></i></a>
+                    <a target="_blank" href="https://www.linkedin.com/in/eilidhsweenie"><i class="fab fa-linkedin"></i></a>
                   </div>
               </figcaption>
             </figure>
@@ -290,7 +290,7 @@ ghost_link: https://www.facebook.com/events/3113267502230875/
                   <h4>Alexandros Angeli</h4>
                   <span class="role">General Board Member</span>
                   <div class="social">
-                    <a target="_blank" href="linkedin.com/in/alexandrosangeli"><i class="fab fa-linkedin"></i></a>
+                    <a target="_blank" href="https://www.linkedin.com/in/alexandrosangeli"><i class="fab fa-linkedin"></i></a>
                   </div>
               </figcaption>
             </figure>


### PR DESCRIPTION
Eilidh's and Alexandros' Linkedin URLs were missing the protocol prefix which caused a wrong redirection.