### PR TITLE
Fixed role titles being cut off

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -745,7 +745,11 @@ svg {
     }
 
     .member .info{
-        width: 20em;
+        width: 9em;
+    }
+
+    .member.selected .info{
+        max-width: 9em;
     }
 
 


### PR DESCRIPTION
Fixed role titles on board member info cards being cut off by expanding the max width by 2em Also shortened width from 22em to 10em to avoid confusion when inspecting elements